### PR TITLE
user PWMRANGE instead off 255

### DIFF
--- a/MotorController.cpp
+++ b/MotorController.cpp
@@ -58,7 +58,7 @@ void MotorController::set(double powerPercent){
       }
       else{
         if (!pin1Direction){
-          analogWrite(forwardPin, 255*setValue);
+          analogWrite(forwardPin, PWMRANGE*setValue);
           analogWrite(backwardPin, 0);
         }
         else{
@@ -75,7 +75,7 @@ void MotorController::set(double powerPercent){
       else{
         if (!pin1Direction){
           analogWrite(forwardPin, 0);
-          analogWrite(backwardPin, 255*-setValue);
+          analogWrite(backwardPin, PWMRANGE*-setValue);
         }
         else{
           digitalWrite(forwardPin, 0);
@@ -87,7 +87,7 @@ void MotorController::set(double powerPercent){
       digitalWrite(forwardPin,0);
       digitalWrite(backwardPin,0);
     }
-    if (enablePin >= 0) analogWrite(enablePin, 255*setValue);
+    if (enablePin >= 0) analogWrite(enablePin, PWMRANGE*setValue);
   }
   timeAtLastSet = millis();
 }


### PR DESCRIPTION
Thanks for this library. It would be nice i it was using PWMRANGE defined in Arduino instead of constant 255. In some platforms (i.e. ESP8266) PWMRANGE is 1023, and using 255 covers only 25% of values.
