### PR TITLE
defining PWMRANGE if not defined

### DIFF
--- a/MotorController.cpp
+++ b/MotorController.cpp
@@ -1,5 +1,9 @@
-#include "MotorController.h"
 #include <Arduino.h>
+#include "MotorController.h"
+
+#ifndef PWMRANGE
+#define PWMRANGE 255
+#endif
 
 MotorController::MotorController(unsigned int forwardsPin, unsigned int backwardsPin, bool pin1IsDirection){
   this->forwardPin = forwardsPin;

--- a/MotorController.cpp
+++ b/MotorController.cpp
@@ -1,10 +1,6 @@
 #include <Arduino.h>
 #include "MotorController.h"
 
-#ifndef PWMRANGE
-#define PWMRANGE 255
-#endif
-
 MotorController::MotorController(unsigned int forwardsPin, unsigned int backwardsPin, bool pin1IsDirection){
   this->forwardPin = forwardsPin;
   this->backwardPin = backwardsPin;

--- a/MotorController.h
+++ b/MotorController.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#ifndef PWMRANGE
+#define PWMRANGE 255
+#endif
+
 class MotorController{
   public:
     /**


### PR DESCRIPTION
After previous merge I realised that indeed PWMRANGE is defined only in arduino.h for esp8266 (with 1024), so it must be defined for original arduinos (with 255).
I have no idea why original arduino does not define this. It seems so obvious.
Now the library is compatible with atmega and esp8266 boards.