### PR TITLE
initialize enabledRampRate to false (default off)

### DIFF
--- a/MotorController.h
+++ b/MotorController.h
@@ -29,7 +29,7 @@ class MotorController{
     bool pin1Direction;
     int enablePin = -1;
     double setValue = 0.0;
-    bool enabledRampRate;
+    bool enabledRampRate = false;
     double rampRate = 1.0;
     long timeAtLastSet = 0;
 };


### PR DESCRIPTION
I've found one more problem. The object variable _enabledRampRate_ was not initialized, and in my case defaulted to true. That caused very weird behaviour of my RC car (delayed response for controls). It took me few days to figure it out. I believe it should be off by default, because is not documented in header file or even mentioned in README.